### PR TITLE
Integrate with Query Designer

### DIFF
--- a/VS.Data.Sqlite/SqliteConnectionSupport.cs
+++ b/VS.Data.Sqlite/SqliteConnectionSupport.cs
@@ -10,6 +10,10 @@ namespace Microsoft.VisualStudio.Data.Sqlite
     {
         protected override object CreateService(IServiceContainer container, Type serviceType)
         {
+            if (serviceType == typeof(IVsDataObjectIdentifierConverter))
+            {
+                return new SqliteObjectIdentifierConverter(Site);
+            }
             if (serviceType == typeof(IVsDataObjectSupport))
             {
                 return new DataObjectSupport(

--- a/VS.Data.Sqlite/SqliteObjectIdentifierConverter.cs
+++ b/VS.Data.Sqlite/SqliteObjectIdentifierConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.VisualStudio.Data.Framework.AdoDotNet;
+using Microsoft.VisualStudio.Data.Services;
+
+namespace Microsoft.VisualStudio.Data.Sqlite
+{
+    class SqliteObjectIdentifierConverter : AdoDotNetObjectIdentifierConverter
+    {
+        public SqliteObjectIdentifierConverter(IVsDataConnection connection)
+            : base(connection)
+        {
+        }
+
+        protected override string FormatPart(string typeName, object identifierPart, DataObjectIdentifierFormat format)
+        {
+            if (identifierPart == null || identifierPart is DBNull)
+                return null;
+
+            var identifierPartString = identifierPart.ToString();
+            if (format.HasFlag(DataObjectIdentifierFormat.WithQuotes)
+                && RequiresQuoting(identifierPartString))
+            {
+                // TODO: Why doesn't Query Designer actually use this?
+                return "\"" + identifierPartString.Replace("\"", "\"\"") + "\"";
+            }
+
+            return identifierPartString;
+        }
+    }
+}

--- a/VS.Data.Sqlite/SqliteObjectSupport.xml
+++ b/VS.Data.Sqlite/SqliteObjectSupport.xml
@@ -23,6 +23,28 @@
             <Parameter value="Tables" />
           </Parameters>
         </Service>
+        <Service type="IDSRefBuilder" implementationType="Microsoft.VisualStudio.Data.Framework.DSRefBuilder">
+          <Parameters method="AppendToDSRef">
+            <Parameter>
+              <!-- Name -->
+              <Parameter value="{0}" />
+              <!-- Owner -->
+              <Parameter />
+              <!-- Type -->
+              <Parameter value="TABLE" />
+              <!-- ExtendedType -->
+              <Parameter />
+              <!-- Properties -->
+              <Parameter>
+                <!-- GUID_DSRefProperty_PreciseType -->
+                <Parameter value="39A5A7E7-513F-44a4-B79D-7652CD8962D9">
+                  <!-- Table -->
+                  <Parameter value="101" type="System.Int32" />
+                </Parameter>
+              </Parameter>
+            </Parameter>
+          </Parameters>
+        </Service>
       </Services>
     </Type>
     <Type name="TableColumn">
@@ -86,6 +108,28 @@
         <Service type="IVsDataObjectSelector" implementationType="Microsoft.VisualStudio.Data.Sqlite.SqliteObjectSelector">
           <Parameters method="SelectObjects">
             <Parameter value="Views" />
+          </Parameters>
+        </Service>
+        <Service type="IDSRefBuilder" implementationType="Microsoft.VisualStudio.Data.Framework.DSRefBuilder">
+          <Parameters method="AppendToDSRef">
+            <Parameter>
+              <!-- Name -->
+              <Parameter value="{0}" />
+              <!-- Owner -->
+              <Parameter />
+              <!-- Type -->
+              <Parameter value="VIEW" />
+              <!-- ExtendedType -->
+              <Parameter />
+              <!-- Properties -->
+              <Parameter>
+                <!-- GUID_DSRefProperty_PreciseType -->
+                <Parameter value="39A5A7E7-513F-44a4-B79D-7652CD8962D9">
+                  <!-- View -->
+                  <Parameter value="301" type="System.Int32" />
+                </Parameter>
+              </Parameter>
+            </Parameter>
           </Parameters>
         </Service>
       </Services>

--- a/VS.Data.Sqlite/SqliteViewSupport.xml
+++ b/VS.Data.Sqlite/SqliteViewSupport.xml
@@ -4,6 +4,9 @@
     <View name="SQLite">
       <ConnectionNode>
         <InitialDisplayName>{Root.DatabaseName}</InitialDisplayName>
+        <Commands>
+          <Command guid="501822E1-B5AF-11d0-B4DC-00A0C91506EF" cmdid="0x3528" provider="884DD964-5327-461f-9F06-6484DD540F8F" />
+        </Commands>
         <Children>
           <StaticNode>
             <DisplayName resource="Tables" />
@@ -15,6 +18,9 @@
                   <Properties>
                     <Property name="Name" />
                   </Properties>
+                  <Commands>
+                    <Command guid="501822E1-B5AF-11d0-B4DC-00A0C91506EF" cmdid="0x3060" provider="884DD964-5327-461f-9F06-6484DD540F8F" />
+                  </Commands>
                   <Children>
                     <StaticNode>
                       <DisplayName resource="Columns" />
@@ -68,6 +74,9 @@
                   <Properties>
                     <Property name="Name" />
                   </Properties>
+                  <Commands>
+                    <Command guid="501822E1-B5AF-11d0-B4DC-00A0C91506EF" cmdid="0x3060" provider="884DD964-5327-461f-9F06-6484DD540F8F" />
+                  </Commands>
                   <Children>
                     <Selection type="ViewColumn" restrictions="{view.Name}" ordering="CID">
                       <SelectionNode>

--- a/VS.Data.Sqlite/VS.Data.Sqlite.csproj
+++ b/VS.Data.Sqlite/VS.Data.Sqlite.csproj
@@ -62,6 +62,7 @@
     <Compile Include="SqliteConnectionUIControl.Designer.cs">
       <DependentUpon>SqliteConnectionUIControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="SqliteObjectIdentifierConverter.cs" />
     <Compile Include="SqliteObjectSelector.cs" />
     <Compile Include="SqliteProviderObjectFactory.cs" />
     <Compile Include="SqliteDataPackage.cs" />


### PR DESCRIPTION
Adds **New Query** and **Retrieve Data** commands.

The query designer is pretty dated and requires a lot of provider support to work well. I'd much rather just integrate with SQLite Toolbox (PR #1).

It might be nice to include the **Retrieve Data** command, however, when SQLite Toolbox isn't installed--just to enable a quick peek at the data inside a table.