### PR TITLE
Added target ARM64 to manifest

### DIFF
--- a/VS.Data.Sqlite/VS.Data.Sqlite.csproj
+++ b/VS.Data.Sqlite/VS.Data.Sqlite.csproj
@@ -172,7 +172,10 @@
     </Content>
     <Content Update="$(PkgSQLitePCLRaw_lib_e_sqlite3)\runtimes\win-x64\native\e_sqlite3.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
-      <VSIXSubPath>.</VSIXSubPath>
+    </Content>
+    <Content Include="$(PkgSQLitePCLRaw_lib_e_sqlite3)\runtimes\win-arm64\native\e_sqlite3.dll">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>runtimes\win-arm64\native</VSIXSubPath>
     </Content>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/VS.Data.Sqlite/source.extension.vsixmanifest
+++ b/VS.Data.Sqlite/source.extension.vsixmanifest
@@ -13,7 +13,7 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
     </Installation>

--- a/VS.Data.Sqlite/source.extension.vsixmanifest
+++ b/VS.Data.Sqlite/source.extension.vsixmanifest
@@ -13,6 +13,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
![SqliteInstallFails](https://github.com/user-attachments/assets/21a4b20d-60c7-4be5-b33b-92055a4a1829)

I'm running Visual Studio 2022 from a Mac using Parallels (Windows 11) and was unable to install.  Once I added ARM64 to manifest I could successfully install.

Fixes #47